### PR TITLE
Switch directly from tree view

### DIFF
--- a/autoload/tree.vim
+++ b/autoload/tree.vim
@@ -146,3 +146,10 @@ function! tree#BufferTree()
   endfor
 
 endfunction
+
+                                                                                
+function! tree#BufferTreeSwitch()                                               
+  call tree#BufferTree()                                                       
+  let switchToBuffer = input('Enter buffer number: ')                          
+  execute('b' . switchToBuffer)                                                
+endfunction

--- a/plugin/buffer-tree.vim
+++ b/plugin/buffer-tree.vim
@@ -11,3 +11,4 @@ if !exists('g:buffertree_arrow')
 endif
 
 command! BufferTree :call tree#BufferTree()
+command! BufferTreeSwitch :call tree#BufferTreeSwitch()


### PR DESCRIPTION
Hi Elliot

Thanks a lot for the plugin!

I've been using vim for a couple of years and then switched to Atom with vim bindings for a few years. I'm just trying to get back to pure terminal vim and feel very disoriented - I'm working on a project which consists of 50+ separate git projects (lots of widgets and such) and my brain feels like playing synchronous blindfold chess hopping that tree.

I just started BufferTree, but I feel I would like to be able to switch the buffer directly from the tree view. So I added a function & command to do that.

I'll need to add a keybinding for BufferTree and see how this approach helps.