### PR TITLE
Fix tree breaking on directory listings

### DIFF
--- a/autoload/tree.vim
+++ b/autoload/tree.vim
@@ -8,12 +8,13 @@ function! GetTree(buffer_numbers)
 
   for buffer_number in a:buffer_numbers
 
-    let file_path = split(expand("#" . string(buffer_number) . ":p"), g:buffertree_path_sep)
+    let file_path = expand("#" . string(buffer_number) . ":p")
+    let path_steps = split(file_path, g:buffertree_path_sep)
     let dir = tree
-    for step in file_path
+    for step in path_steps
 
       " check if this is the end
-      if len(file_path) == 1
+      if len(path_steps) == 1 && !isdirectory(file_path)
         let dir[step] = buffer_number
       else
         if !has_key(dir, step)
@@ -22,7 +23,7 @@ function! GetTree(buffer_numbers)
         let dir = dir[step]
       endif
 
-      let file_path = file_path[1:]
+      let path_steps = path_steps[1:]
 
     endfor
   endfor


### PR DESCRIPTION
This fixes an error when a buffer contains a folder and another buffer contains a file in that folder.

Example repro steps:
1. open c:\myfolder in a buffer (a directory listing)
2. open c:\myfolder\foo.txt in a buffer
3. run BufferTree

In the first iteration of GetTree, the folder will be added as a `buffer_number`, not as a dictionary. The second iteration then throws an error when trying to use it as a dictionary in `let dir = dir[step]`.

The fix is to add directories as dictionaries, always.